### PR TITLE
chore: bump cargo-shear to 1.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@
     # cache `target` directory to avoid download crates
     save-cache: ${{ github.ref_name == 'main' }}
     cache-key: warm
-    tools: just,cargo-shear@1,dprint
+    tools: just,cargo-shear@1.13.1,dprint
     components: clippy rustfmt
 ```


### PR DESCRIPTION
Pins the cargo-shear setup example to 1.13.1.